### PR TITLE
Split CI so that we can diagnose issues with steps separately

### DIFF
--- a/.github/workflows/abaplint.yml
+++ b/.github/workflows/abaplint.yml
@@ -1,0 +1,31 @@
+name: Main CI Checks
+
+on:
+  pull_request:
+  push:
+      branches:
+        - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Node.js for use with actions
+      uses: actions/setup-node@v1.1.0
+    - name: NPM Install
+      run: npm ci 
+      
+  abaplint:
+
+    runs-on: ubuntu-latest
+    name: ABAPLint
+    needs: [build]
+
+    steps:
+    - name: abaplint Action
+      uses: abaplint/actions-abaplint@0.2.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,15 +35,3 @@ jobs:
       with:
         # Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}
         repo-token: ${{ secrets.GITHUB_TOKEN }} 
-
-  abaplint:
-
-    runs-on: ubuntu-latest
-    name: ABAPLint
-    needs: [build]
-
-    steps:
-    - name: abaplint Action
-      uses: abaplint/actions-abaplint@0.2.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  


### PR DESCRIPTION
Splitting CI so that we can diagnose issues with ESLint and ABAPLint separately.